### PR TITLE
Properly shell escape git_with_submodule_and_resolv_symlinks:wrapper steps as same as git:wrapper

### DIFF
--- a/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks.rb
+++ b/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks.rb
@@ -1,5 +1,6 @@
 require 'capistrano/scm/plugin'
 require 'capistrano/scm/git_with_submodule_and_resolv_symlinks/version'
+require 'shellwords'
 
 module Capistrano
   class SCM
@@ -12,7 +13,7 @@ module Capistrano
         set_if_empty :"#{nsp}_wrapper_path", lambda {
           # Try to avoid permissions issues when multiple users deploy the same app
           # by using different file names in the same dir for each deployer and stage.
-          suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-").gsub(/\s+/, "-")
+          suffix = [:application, :stage, :local_user].map { |key| fetch(key).to_s }.join("-")
           "#{fetch(:tmp_dir)}/git-ssh-#{suffix}.sh"
         }
         set_if_empty :"#{nsp}_environmental_variables", lambda {

--- a/lib/capistrano/scm/tasks/git_with_submodule_and_resolv_symlinks.rake
+++ b/lib/capistrano/scm/tasks/git_with_submodule_and_resolv_symlinks.rake
@@ -5,9 +5,9 @@ namespace scm.nsp do
   desc "Upload the git wrapper script, this script guarantees that we can script git without getting an interactive prompt"
   task :wrapper do
     on release_roles :all do
-      execute :mkdir, "-p", File.dirname(fetch(:"#{scm.nsp}_wrapper_path"))
+      execute :mkdir, "-p", File.dirname(fetch(:"#{scm.nsp}_wrapper_path")).shellescape
       upload! StringIO.new("#!/bin/sh -e\nexec /usr/bin/ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no \"$@\"\n"), fetch(:"#{scm.nsp}_wrapper_path")
-      execute :chmod, "700", fetch(:"#{scm.nsp}_wrapper_path")
+      execute :chmod, "700", fetch(:"#{scm.nsp}_wrapper_path").shellescape
     end
   end
 

--- a/spec/capistrano/scm/git_with_submodule_and_resolv_symlinks_spec.rb
+++ b/spec/capistrano/scm/git_with_submodule_and_resolv_symlinks_spec.rb
@@ -25,6 +25,17 @@ module Capistrano
       Capistrano::Configuration.reset!
     end
 
+    describe "#set_defaults" do
+      it "makes git_wrapper_path using application, stage, and local_user" do
+        env.set(:tmp_dir, "/tmp")
+        env.set(:application, "my_app")
+        env.set(:stage, "staging")
+        env.set(:local_user, "(Git Web User) via ShipIt")
+        subject.set_defaults
+        expect(env.fetch(:git_with_submodule_and_resolv_symlinks_wrapper_path)).to eq("/tmp/git-ssh-my_app-staging-(Git Web User) via ShipIt.sh")
+      end
+    end
+
     describe "#git" do
       it "should call git in the context, with arguments" do
         backend.expects(:execute).with(:git, :init)


### PR DESCRIPTION
see also:
https://github.com/capistrano/capistrano/pull/1840
https://github.com/capistrano/capistrano/pull/1843