### PR TITLE
Move git-specific repo_url logic into GitWithSubmoduleAndResolvSymlinks plugin as same as Git plugin

### DIFF
--- a/spec/capistrano/scm/git_with_submodule_and_resolv_symlinks_spec.rb
+++ b/spec/capistrano/scm/git_with_submodule_and_resolv_symlinks_spec.rb
@@ -71,6 +71,20 @@ module Capistrano
       end
     end
 
+    context "with username and password specified" do
+      before do
+        env.set(:git_http_username, "hello")
+        env.set(:git_http_password, "topsecret")
+        env.set(:repo_url, "https://example.com/repo.git")
+        env.set(:repo_path, "path")
+      end
+
+      it "should include the credentials in the url" do
+        backend.expects(:execute).with(:git, :clone, "https://hello:topsecret@example.com/repo.git", "path")
+        subject.clone_repo
+      end
+    end
+
     describe "#update_mirror" do
       describe "with branch" do
         it "should run git remote set-url, git remote update, git checkout, git submodle update" do


### PR DESCRIPTION
see also:
https://github.com/capistrano/capistrano/pull/1859