### PR TITLE
Support capistrano 3.8

### DIFF
--- a/capistrano-scm-git_with_submodule_and_resolv_symlinks.gemspec
+++ b/capistrano-scm-git_with_submodule_and_resolv_symlinks.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capistrano", "~> 3.7.0"
+  spec.add_dependency "capistrano", ">= 3.7.0", "< 3.9.0"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks/version.rb
+++ b/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks/version.rb
@@ -13,7 +13,7 @@ end
 module Capistrano
   class SCM
     class GitWithSubmoduleAndResolvSymlinks < ::Capistrano::SCM::Plugin
-      VERSION = "0.1.1"
+      VERSION = "0.2.0"
     end
   end
 end


### PR DESCRIPTION
Updated dependency to support [capistrano 3.8.0](https://github.com/capistrano/capistrano/blob/v3.8.0/CHANGELOG.md), and I will release capistrano-scm-git_with_submodule_and_resolv_symlinks v0.2.0

