### PR TITLE
Relax dependency version of capistrano (support capistrano 3.9.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.6
-  - 2.3.3
-before_install: gem install bundler -v 1.12.5
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+before_install: gem install bundler -v 1.15.3

--- a/capistrano-scm-git_with_submodule_and_resolv_symlinks.gemspec
+++ b/capistrano-scm-git_with_submodule_and_resolv_symlinks.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capistrano", ">= 3.7.0", "< 3.9.0"
+  spec.add_dependency "capistrano", ">= 3.7.0", "< 3.10.0"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/capistrano-scm-git_with_submodule_and_resolv_symlinks.gemspec
+++ b/capistrano-scm-git_with_submodule_and_resolv_symlinks.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "capistrano", ">= 3.7.0", "< 3.10.0"
   spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "mocha", "~> 1.2"
 end

--- a/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks/version.rb
+++ b/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks/version.rb
@@ -13,7 +13,7 @@ end
 module Capistrano
   class SCM
     class GitWithSubmoduleAndResolvSymlinks < ::Capistrano::SCM::Plugin
-      VERSION = "0.2.0"
+      VERSION = "0.2.1"
     end
   end
 end


### PR DESCRIPTION
Updated dependency to support [capistrano 3.9.0](https://github.com/capistrano/capistrano/blob/v3.9.0/CHANGELOG.md), and I will release capistrano-scm-git_with_submodule_and_resolv_symlinks v0.2.1