### PR TITLE
current_revision as non-abbreviated commit object name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
-before_install: gem install bundler -v 1.15.4
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
+before_install: gem install bundler -v 1.16.1

--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ but Capistrano::SCM::GitWithSubmoduleAndResolvSymlinks creates `repo_path` as no
 
 If you want to switch SCM, delete `repo_path` before deploy.
 
-### `current_revision` is abbreviated
-
-With Capistrano::SCM::Git, `current_version` is non-abbreviated commit hash (like `81cec13b777ff46348693d327fc8e7832f79bf43`),
-but with Capistrano::SCM::GitWithSubmoduleAndResolvSymlinks, `current_version` is abbreviated (like `81cec13`).
-
 ### Shallow clone is not supported
 
 Capistrano::SCM::Git supports shallow clone by configuration variable `:git_shallow_clone`,

--- a/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks.rb
+++ b/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks.rb
@@ -65,7 +65,7 @@ module Capistrano
       end
 
       def fetch_revision
-        backend.capture(:git, "rev-list", "--max-count=1", "--abbrev-commit", real_branch)
+        backend.capture(:git, "rev-list", "--max-count=1", real_branch)
       end
 
       def real_branch

--- a/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks/version.rb
+++ b/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks/version.rb
@@ -13,7 +13,7 @@ end
 module Capistrano
   class SCM
     class GitWithSubmoduleAndResolvSymlinks < ::Capistrano::SCM::Plugin
-      VERSION = "0.2.2"
+      VERSION = "0.3.0"
     end
   end
 end

--- a/spec/capistrano/scm/git_with_submodule_and_resolv_symlinks_spec.rb
+++ b/spec/capistrano/scm/git_with_submodule_and_resolv_symlinks_spec.rb
@@ -143,9 +143,9 @@ module Capistrano
         it "should capture git rev-list" do
           env.set(:branch, "real-branch")
           backend.expects(:test).with(:git, :"rev-parse", "origin/real-branch").returns(true)
-          backend.expects(:capture).with(:git, "rev-list", "--max-count=1", "--abbrev-commit", "origin/real-branch").returns("81cec13")
+          backend.expects(:capture).with(:git, "rev-list", "--max-count=1", "origin/real-branch").returns("81cec13b777ff46348693d327fc8e7832f79bf44")
           revision = subject.fetch_revision
-          expect(revision).to eq("81cec13")
+          expect(revision).to eq("81cec13b777ff46348693d327fc8e7832f79bf44")
         end
       end
 

--- a/spec/capistrano/scm/git_with_submodule_and_resolv_symlinks_spec.rb
+++ b/spec/capistrano/scm/git_with_submodule_and_resolv_symlinks_spec.rb
@@ -153,9 +153,9 @@ module Capistrano
         it "should capture git rev-list" do
           env.set(:branch, "tag-or-commit")
           backend.expects(:test).with(:git, :"rev-parse", "origin/tag-or-commit").returns(false)
-          backend.expects(:capture).with(:git, "rev-list", "--max-count=1", "--abbrev-commit", "tag-or-commit").returns("81cec13")
+          backend.expects(:capture).with(:git, "rev-list", "--max-count=1", "tag-or-commit").returns("81cec13b777ff46348693d327fc8e7832f79bf44")
           revision = subject.fetch_revision
-          expect(revision).to eq("81cec13")
+          expect(revision).to eq("81cec13b777ff46348693d327fc8e7832f79bf44")
         end
       end
     end


### PR DESCRIPTION
before:

```ruby
fetch(:current_revision) # => "81cec13"
```

after:

```ruby
fetch(:current_revision) # => "81cec13b777ff46348693d327fc8e7832f79bf44"
```