### PR TITLE
Relax dependency version of capistrano (support capistrano 3.11.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 rvm:
   - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
-before_install: gem install bundler -v 1.16.1
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
+before_install: gem install bundler -v 1.16.2

--- a/capistrano-scm-git_with_submodule_and_resolv_symlinks.gemspec
+++ b/capistrano-scm-git_with_submodule_and_resolv_symlinks.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capistrano", ">= 3.7.0", "< 3.11.0"
+  spec.add_dependency "capistrano", ">= 3.7.0", "< 3.12.0"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks/version.rb
+++ b/lib/capistrano/scm/git_with_submodule_and_resolv_symlinks/version.rb
@@ -13,7 +13,7 @@ end
 module Capistrano
   class SCM
     class GitWithSubmoduleAndResolvSymlinks < ::Capistrano::SCM::Plugin
-      VERSION = "0.3.0"
+      VERSION = "0.3.1"
     end
   end
 end


### PR DESCRIPTION
Updated dependency to support [capistrano 3.11.0](https://github.com/capistrano/capistrano/blob/v3.11.0/CHANGELOG.md#3110-2018-06-02)