### PR TITLE
Maintenance CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: [2.5, 2.6, 2.7]
+      fail-fast: false
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+      - uses: actions/checkout@master
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - run: bundle config path vendor/bundle
+      - run: bundle install --jobs=4 --retry=3
+      - run: bundle exec rake spec
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+
+      - run: ruby --version
+      - run: gem --version
+      - run: gem env
+      - run: bundle --version
+
       - run: bundle config path vendor/bundle
       - run: bundle install --jobs=4 --retry=3
       - run: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
-before_install: gem install bundler -v 1.17.2

--- a/capistrano-scm-git_with_submodule_and_resolv_symlinks.gemspec
+++ b/capistrano-scm-git_with_submodule_and_resolv_symlinks.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano", ">= 3.7.0", "< 3.12.0"
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "mocha", "~> 1.2"


### PR DESCRIPTION
CI (Travis CI, Ruby 2.5.3) for #10 failed with following error.

```
$ bundle install --jobs=3 --retry=3
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.12)
  Current Bundler version:
    bundler (2.0.1)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
Could not find gem 'bundler (~> 1.12)' in any of the relevant sources:
  the local ruby installation
```

So I changed below to fix/maintenance CI:

- Removed bundler gem version specifier from gemspec file
- Migrated CI service from Travis CI to GitHub Actions
- Updated ruby versions to test

